### PR TITLE
[RFC] u-boot: enable CDP network protocol support

### DIFF
--- a/configurations/u-boot/patches/0013-urwerk-config-add-cdp-support.patch
+++ b/configurations/u-boot/patches/0013-urwerk-config-add-cdp-support.patch
@@ -1,0 +1,12 @@
+Index: u-boot-2017.03/cmd/Kconfig
+===================================================================
+--- u-boot-2017.03.orig/cmd/Kconfig
++++ u-boot-2017.03/cmd/Kconfig
+@@ -586,6 +586,7 @@ config CMD_PING
+ 
+ config CMD_CDP
+ 	bool "cdp"
++	default y
+ 	help
+ 	  Perform CDP network configuration
+ 

--- a/configurations/u-boot/patches/0014-dont-wait-for-cdp-reply.patch
+++ b/configurations/u-boot/patches/0014-dont-wait-for-cdp-reply.patch
@@ -1,0 +1,13 @@
+Index: u-boot-2017.03/net/cdp.c
+===================================================================
+--- u-boot-2017.03.orig/net/cdp.c
++++ u-boot-2017.03/net/cdp.c
+@@ -37,7 +37,7 @@ const u8 net_cdp_ethaddr[6] = { 0x01, 0x
+ #define CDP_TIMEOUT			250UL	/* one packet every 250ms */
+ 
+ static int cdp_seq;
+-static int cdp_ok;
++static int cdp_ok = 1;
+ 
+ ushort cdp_native_vlan;
+ ushort cdp_appliance_vlan;


### PR DESCRIPTION
Patch Kconfig to select CONFIG_CMD_CDP by default (the blickwerk build
system currently only calls urwerk_${VARIANT}_defconfig and doesn't
allow subsequent modification of the resulting configuration, hence
patching Kconfig was the most convenient one-liner to test this).

Signed-off-by: Daniel Golle <daniel@makrotopia.org>