### PR TITLE
[RFC] dts: use auart4 also in development mode

### DIFF
--- a/configurations/linux/patches/0013-use-aurt4-in-development-variant.patch
+++ b/configurations/linux/patches/0013-use-aurt4-in-development-variant.patch
@@ -1,0 +1,31 @@
+Index: linux-4.4.182/arch/arm/boot/dts/urwerk-develop.dts
+===================================================================
+--- linux-4.4.182.orig/arch/arm/boot/dts/urwerk-develop.dts
++++ linux-4.4.182/arch/arm/boot/dts/urwerk-develop.dts
+@@ -20,12 +20,23 @@
+ //            USB-Debug-Mode:  DUART on external serial port, AUART4 disabled
+ //*************************************************************/
+ 
++/ {
++	aliases {
++		serial0 = &auart4;
++	};
++
++	chosen {
++		bootargs = "console=ttyAPP4,115200";
++		stdout-path = "serial0:115200n8";
++	};
++};
++
+ &duart {
+-	// duart on Urwerk's external RS232-Pins
+-	pinctrl-0 = <&duart_pins_b>;
++	// duart on Urwerk testpads
++	pinctrl-0 = <&duart_pins_a>;
+ 	status = "ok";
+ };
+ 
+ &auart4 {
+-	status = "disabled";
++	status = "ok";
+ };


### PR DESCRIPTION
duart got no DMA and is named differently in userspace.
Make things more consistent by always using auart4, but in development
mode also using it as the primary console for Linux.
The result should be similar to having duart routed to the external
pins, just that now the serial device is named ttyAPP4 and DMA
operation should work.

Fixes #6
Fixes #9

Signed-off-by: Daniel Golle <daniel@makrotopia.org>